### PR TITLE
Feature/elias display list notifications

### DIFF
--- a/Config/Database.php
+++ b/Config/Database.php
@@ -109,6 +109,16 @@ class Database
     }
 
     /**
+     * Get the result of COUNT(*) as an integer
+     *
+     * @return int The count result.
+     */
+    public function fetchCount()
+    {
+        return (int) $this->stmt->fetchColumn();
+    }
+
+    /**
      * Get a single record as an object
      *
      * @return object The single record.

--- a/app/Controller/NutritionistController.php
+++ b/app/Controller/NutritionistController.php
@@ -43,7 +43,7 @@ class NutritionistController
         $searchValue = isset($_GET['searchValue']) ? $_GET['searchValue'] : '';
 
         if (!empty($searchValue)) {
-            $data = $this->nutriModel->getUserByFullname($searchValue, "Regular");
+            $data = $this->nutriModel->getUserByFullname($searchValue, $_SESSION['role']);
 
             if ($data) {
                 ob_start();
@@ -86,39 +86,33 @@ class NutritionistController
     }
 
 
-        /**
-         * Show All Cients for a Nutritionist
-         *
-         * Retrieves all clients for a given nutritionist from the model and display them through <strong>clients-table.php</strong>.
-         *
-         * @param int $nutritionistId The ID of the nutritionist
-         * @return void
-         */
-        public function getUsersForNutritionist()
-        {
-            header('APPJSON');
-            $nutritionistId = isset($_GET['nutri_id']) ? $_GET['nutri_id'] : '';
+    /**
+     * Show All Cients for a Nutritionist
+     *
+     * Retrieves all clients for a given nutritionist from the model and display them through <strong>clients-table.php</strong>.
+     *
+     * @param int $nutritionistId The ID of the nutritionist
+     * @return void
+     */
+    public function getUsersForNutritionist()
+    {
+        header('APPJSON');
+        $nutritionistId = isset($_GET['nutri_id']) ? $_GET['nutri_id'] : '';
 
-            // Call the model method to get users for the nutritionist
-            $data = $this->nutriModel->getUsersForNutritionist($nutritionistId);
+        // Call the model method to get users for the nutritionist
+        $data = $this->nutriModel->getUsersForNutritionist($nutritionistId);
 
-            if ($data) {
-                // Output buffering to capture the included file's content
-                ob_start();
-                include VIEWSDIR . DS . 'components' . DS . 'nutritionist' . DS . 'list-client-element.php';
-                $output = ob_get_clean();
+        if ($data) {
+            // Output buffering to capture the included file's content
+            ob_start();
+            include VIEWSDIR . DS . 'components' . DS . 'nutritionist' . DS . 'list-client-element.php';
+            $output = ob_get_clean();
 
-                // Echo the content captured, which now includes $data being used in usersList.php
-                echo json_encode(['message' => $output]);
-            } else {
-                echo json_encode(['message' => '<h3 class="text-center text-secondary mt-5">:( No clients present for this nutritionist!</h3>']);
-            }
-            exit;
+            // Echo the content captured, which now includes $data being used in usersList.php
+            echo json_encode(['message' => $output]);
+        } else {
+            echo json_encode(['message' => '<h3 class="text-center text-secondary mt-5">:( No clients present for this nutritionist!</h3>']);
         }
-
-
-
-
-
-
+        exit;
+    }
 }

--- a/app/Controller/Users.php
+++ b/app/Controller/Users.php
@@ -363,4 +363,28 @@ class Users
 
         exit;
     }
+
+    /**
+     * getUsersFromNotifications
+     * 
+     * Asks the Model for all notification senders' information,
+     * in order to display them
+     *
+     * @return void
+     */
+    public function getUsersFromNotifications()
+    {
+        header('APPJSON');
+
+        $data = $this->userModel->getUsersByNotifs();
+
+        if ($data) {
+            ob_start();
+            include VIEWSDIR . DS . 'components' . DS . 'user' . DS . 'dashboard' . DS . 'senderNotifList.php';
+            $output = ob_get_clean();
+            echo json_encode(['success' => true, 'data' => $output]);
+        } else {
+            echo json_encode(['success' => false, 'message' => 'Users from notification query failed.']);
+        }
+    }
 }

--- a/app/Controller/Users.php
+++ b/app/Controller/Users.php
@@ -403,7 +403,7 @@ class Users
         $data = $this->userModel->updateNotificationState();
 
         if ($data[0]) {
-            echo json_encode(['success' => true, 'data' => $data[1]]);
+            echo json_encode(['success' => true, 'requestType' => $data[2], 'data' => $data[1]]);
         } else {
             echo json_encode(['success' => false, 'message' => $data[1]]);
         }

--- a/app/Controller/Users.php
+++ b/app/Controller/Users.php
@@ -387,4 +387,25 @@ class Users
             echo json_encode(['success' => false, 'message' => 'Users from notification query failed.']);
         }
     }
+
+    /**
+     * updateNotificationState
+     * 
+     * Asks the Model to update the notification, meaning either decline or accept it,
+     * based on the content of the POST request
+     *
+     * @return void
+     */
+    public function updateNotificationState()
+    {
+        header('APPJSON');
+
+        $data = $this->userModel->updateNotificationState();
+
+        if ($data[0]) {
+            echo json_encode(['success' => true, 'data' => $data[1]]);
+        } else {
+            echo json_encode(['success' => false, 'message' => $data[1]]);
+        }
+    }
 }

--- a/app/Model/NutritionistModel.php
+++ b/app/Model/NutritionistModel.php
@@ -66,10 +66,13 @@ class NutritionistModel
      */
     private function checkIfWaitingNotification($receiverID, $senderID)
     {
-        $this->db->query("SELECT * FROM notifications WHERE receiver_id = :receiverID AND sender_id = :senderID AND type = 1");
+        $this->db->query("SELECT COUNT(*) FROM notifications WHERE receiver_id = :receiverID AND sender_id = :senderID AND type = 1");
         $this->db->bind(':receiverID', $receiverID);
         $this->db->bind(':senderID', $senderID);
-        return $this->db->rowCount() > 0;
+        $this->db->execute();
+        $count = $this->db->fetchCount(); // Récupérer le résultat COUNT(*)
+
+        return $count > 0;
     }
 
 
@@ -78,8 +81,8 @@ class NutritionistModel
      * 
      * Fetch the email of the user clicked on, then send them a notification through the database
      *
-     * @param  mixed $receiverID
-     * @param  mixed $senderID
+     * @param  mixed $receiverID Id clicked on
+     * @param  mixed $senderID Own Id, stocked in the session
      * @return bool|mixed return the user clicked on on success, to send them an email
      */
     public function checkNotifThenSend($receiverID, $senderID)
@@ -90,8 +93,8 @@ class NutritionistModel
 
 
         $result = $this->db->single();
+        if (!empty($result) && !$this->checkIfWaitingNotification($receiverID, $senderID)) {
 
-        if (!empty($result && !$this->checkIfWaitingNotification($receiverID, $senderID))) {
             //  si utilisateur existe, et si pas de notif déjà en attente d'accept/decline
             $addQuery = "INSERT INTO notifications (`receiver_id`,`sender_id`,`type`) VALUES (:receiverID,:senderID,1)";
             $this->db->query($addQuery);

--- a/app/Model/NutritionistModel.php
+++ b/app/Model/NutritionistModel.php
@@ -59,6 +59,7 @@ class NutritionistModel
      * checkIfWaitingNotification
      * 
      * Check if a notification already exists with the given receiver and sender ids and type 1
+     * by counting the number of rows affected
      *
      * @param int $receiverID
      * @param int $senderID

--- a/app/Model/NutritionistModel.php
+++ b/app/Model/NutritionistModel.php
@@ -33,10 +33,17 @@ class NutritionistModel
      */
     public function getUserByFullname($namePart, $userType)
     {
-        $sql = "SELECT * FROM users WHERE fullname LIKE CONCAT('%', :namePart, '%') AND role=:userType;";
+        if ($userType == "Regular") { // les regular verront les nutritionnistes
+            $targetType = "Nutritionist";
+        } else if ($userType == "Nutritionist") { // les nutritionnistes verront les regular
+            $targetType = "Regular";
+        } else { // juste pour éviter les bugs si un admin cherche ( admin n'est pas censé chercher though)
+            $targetType = "Admin";
+        }
+        $sql = "SELECT * FROM users WHERE fullname LIKE CONCAT('%', :namePart, '%') AND role=:targetType LIMIT 4;";
         $this->db->query($sql);
         $this->db->bind(':namePart', $namePart);
-        $this->db->bind(':userType', $userType);
+        $this->db->bind(':targetType', $targetType);
 
 
         $results = $this->db->resultSet();
@@ -88,39 +95,35 @@ class NutritionistModel
      * @param int $nutritionistId The ID of the nutritionist
      * @return array|false An array of user data if users are found, or false if no users are present.
      */
-        public function getUsersForNutritionist($nutritionistId)
-        {
-            $data = array();
-            // Construct the SQL query with a join operation
-            $sql = "SELECT u.* 
+    public function getUsersForNutritionist($nutritionistId)
+    {
+        $data = array();
+        // Construct the SQL query with a join operation
+        $sql = "SELECT u.* 
                     FROM users u
                     JOIN nutritionist_client nc ON u.id = nc.client_id
                     WHERE nc.nutritionist_id = :nutritionist_id";
 
 
-            // Prepare the query
-            $this->db->query($sql);
-            // Bind the nutritionist ID parameter
-            $this->db->bind(':nutritionist_id', $nutritionistId);
-            // Execute the query
-            $rows = $this->db->resultSet();
+        // Prepare the query
+        $this->db->query($sql);
+        // Bind the nutritionist ID parameter
+        $this->db->bind(':nutritionist_id', $nutritionistId);
+        // Execute the query
+        $rows = $this->db->resultSet();
 
-            // Check if any rows were returned
-            if ($this->db->rowCount() > 0) {
-                // If rows are found, iterate through them and add to the data array
-                foreach ($rows as $row) {
-                    $data[] = $row;
-                }
-                // Return the data array
-
-                return $data;
-            } else {
-                // If no rows are found, return false
-                return false;
+        // Check if any rows were returned
+        if ($this->db->rowCount() > 0) {
+            // If rows are found, iterate through them and add to the data array
+            foreach ($rows as $row) {
+                $data[] = $row;
             }
+            // Return the data array
+
+            return $data;
+        } else {
+            // If no rows are found, return false
+            return false;
         }
-
-
-
-
+    }
 }

--- a/app/Model/NutritionistModel.php
+++ b/app/Model/NutritionistModel.php
@@ -56,6 +56,24 @@ class NutritionistModel
     }
 
     /**
+     * checkIfWaitingNotification
+     * 
+     * Check if a notification already exists with the given receiver and sender ids and type 1
+     *
+     * @param int $receiverID
+     * @param int $senderID
+     * @return bool
+     */
+    private function checkIfWaitingNotification($receiverID, $senderID)
+    {
+        $this->db->query("SELECT * FROM notifications WHERE receiver_id = :receiverID AND sender_id = :senderID AND type = 1");
+        $this->db->bind(':receiverID', $receiverID);
+        $this->db->bind(':senderID', $senderID);
+        return $this->db->rowCount() > 0;
+    }
+
+
+    /**
      * checkNotifThenSend
      * 
      * Fetch the email of the user clicked on, then send them a notification through the database
@@ -73,7 +91,8 @@ class NutritionistModel
 
         $result = $this->db->single();
 
-        if (!empty($result)) {
+        if (!empty($result && !$this->checkIfWaitingNotification($receiverID, $senderID))) {
+            //  si utilisateur existe, et si pas de notif déjà en attente d'accept/decline
             $addQuery = "INSERT INTO notifications (`receiver_id`,`sender_id`,`type`) VALUES (:receiverID,:senderID,1)";
             $this->db->query($addQuery);
             $this->db->bind(':receiverID', $receiverID);

--- a/app/Model/NutritionistModel.php
+++ b/app/Model/NutritionistModel.php
@@ -70,7 +70,7 @@ class NutritionistModel
         $this->db->bind(':receiverID', $receiverID);
         $this->db->bind(':senderID', $senderID);
         $this->db->execute();
-        $count = $this->db->fetchCount(); // Récupérer le résultat COUNT(*)
+        $count = $this->db->fetchCount(); // récupère le résultat COUNT(*)
 
         return $count > 0;
     }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -309,6 +309,7 @@ class User
                     $data[] = $row;
                 }
             }
+            // hors du if, sinon lorsqu'il n'y a pas de notification, la session gardera l'ancienne version de $data
             $_SESSION['notifications'] = $data;
             return $nbrRows;
         } else {
@@ -328,7 +329,8 @@ class User
     {
         $notifList = $_SESSION['notifications'];
 
-        if ($notifList != NULL) {
+        if (!empty($notifList)) {
+            $senderList = [];
             foreach ($notifList as $notif) {
                 $sql = "SELECT * FROM users WHERE id=:senderId";
                 $this->db->query($sql);
@@ -336,6 +338,7 @@ class User
                 $sender = $this->db->single();
 
                 if ($sender) {
+                    $sender->notification_type = $notif->type;
                     $senderList[] = $sender;
                 }
             }
@@ -417,7 +420,7 @@ class User
                     return array(false, $returnMessage);
                 }
             }
-            return array(false, "Connection already exists;");
+            return array(true, "Connection already exists;");
         }
 
         return array(true, "All good");

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -473,7 +473,8 @@ class User
             if (!$this->checkIfConnectionExists($userId, $senderId, $userRole)) {
                 return $this->modifyConnection($userRole, $senderId, $userId, $this->db, "insert");
             } else {
-                return array(false, "Connection already exists");
+                return array(true, $this->getSingleUserById($senderId), "insert"); // cas où A envoie une notif que B accepte, puis B envoie une notif que A veut accepter
+
             }
         } else if ($newNotifState == 3) { // If Decline -> deletion
             if ($this->checkIfConnectionExists($userId, $senderId, $userRole)) { // regarde si la connexion existe avant

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -403,7 +403,7 @@ class User
             return array(false, $returnMessage);
         }
 
-        return array(true, $requestType . "d successfully");
+        return array(true, $requestType . "ed successfully");
     }
 
 
@@ -433,7 +433,7 @@ class User
         }
 
 
-        $this->db->query('UPDATE notifications SET type=:newState WHERE sender_id=:senderId AND receiver_id=:userId');
+        $this->db->query('UPDATE notifications SET type=:newState WHERE sender_id=:senderId AND receiver_id=:userId AND type=1');
         $this->db->bind(':newState', $newNotifState);
         $this->db->bind(':senderId', $senderId);
         $this->db->bind(':userId', $userId);
@@ -446,11 +446,14 @@ class User
         if ($newNotifState == 2) { // If Accept -> insertion
             if (!$this->checkIfConnectionExists($userId, $senderId)) {
                 return $this->modifyConnection($userRole, $senderId, $userId, $this->db, "insert");
+            } else {
+                return array(false, "Connection already exists");
             }
-            return array(true, "Connection already exists;");
         } else if ($newNotifState == 3) { // If Decline -> deletion
             if ($this->checkIfConnectionExists($userId, $senderId)) { // regarde si la connexion existe avant
                 return $this->modifyConnection($userRole, $senderId, $userId, $this->db, "delete");
+            } else {
+                return array(false, "No connection to delete");
             }
         } else {
             return array(false, "Notification State " . $newNotifState . " not allowed");

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -299,18 +299,47 @@ class User
         $this->db->query($sql);
         $this->db->bind(':userId', $userId);
         $rows = $this->db->resultSet();
+        $nbrRows = $this->db->rowCount();
 
-        if ($this->db->rowCount() >= 0) {
-            foreach ($rows as $row) {
-                $data[] = $row;
+        if ($nbrRows >= 0) {
+
+            if ($nbrRows > 0) {
+                foreach ($rows as $row) {
+                    $data[] = $row;
+                }
+                $_SESSION['notifications'] = $data;
             }
-            if ($data == null) {
-                $data = 0;
-            }
-            $_SESSION['notifications'] = $data;
-            return $this->db->rowCount();
+            return $nbrRows;
         } else {
-            return false;
+            return 0;
         }
+    }
+
+    /**
+     * getUsersByNotifs
+     * 
+     * Use the list of notifications in the dataabse to get access to all users who sent notifications
+     * to the current connected user, then put their data in an array and return it
+     *
+     * @return bool|object[]
+     */
+    public function getUsersByNotifs()
+    {
+        $notifList = $_SESSION['notifications'];
+
+        if ($notifList != NULL) {
+            foreach ($notifList as $notif) {
+                $sql = "SELECT * FROM users WHERE id=:senderId";
+                $this->db->query($sql);
+                $this->db->bind(':senderId', $notif->sender_id);
+                $sender = $this->db->single();
+
+                if ($sender) {
+                    $senderList[] = $sender;
+                }
+            }
+            return $senderList;
+        }
+        return false;
     }
 }

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -373,6 +373,21 @@ class User
         return $this->db->fetchCount(); // récupère le résultat COUNT(*)
     }
 
+    /**
+     * Retrieves user information based on the user's ID.
+     *
+     * @param int $senderId The ID of the user.
+     * @return mixed The user information or false in case of an error.
+     */
+    public function getSingleUserById($senderId)
+    {
+        $sql = "SELECT * FROM users WHERE id = :senderId";
+        $this->db->query($sql);
+        $this->db->bind(':senderId', $senderId);
+        return $this->db->single();
+    }
+
+
 
     /**
      * Add or Delete a connection into the nutritionist_client table.
@@ -382,7 +397,7 @@ class User
      * @param int $userId The ID of the user.
      * @param Database $db The database connection.
      * @param string $requestType The type of request to execute, can be either "insert" or "delete"
-     * @return array An array indicating success or failure along with a message.
+     * @return array An array indicating success or failure along with a message, and if success, the data of the sender
      */
     private function modifyConnection($userRole, $senderId, $userId, $db, string $requestType)
     {
@@ -413,7 +428,8 @@ class User
             return array(false, $returnMessage);
         }
 
-        return array(true, $requestType . "ed successfully");
+
+        return array(true, $this->getSingleUserById($senderId), $requestType);
     }
 
 
@@ -463,7 +479,7 @@ class User
             if ($this->checkIfConnectionExists($userId, $senderId, $userRole)) { // regarde si la connexion existe avant
                 return $this->modifyConnection($userRole, $senderId, $userId, $this->db, "delete");
             } else {
-                return array(false, "No connection to delete between " . $userId . " and " . $senderId);
+                return array(true, $this->getSingleUserById($senderId), "delete"); // cas où décline, et pas déjà de connection dans la db
             }
         } else {
             return array(false, "Notification State " . $newNotifState . " not allowed");

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -320,7 +320,7 @@ class User
     /**
      * getUsersByNotifs
      * 
-     * Use the list of notifications in the dataabse to get access to all users who sent notifications
+     * Use the list of notifications in the database to get access to all users who sent notifications
      * to the current connected user, then put their data in an array and return it
      *
      * @return bool|object[]

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -130,7 +130,6 @@ class User
 
 
 
-    //Login user
     /**
      * Login
      *
@@ -301,14 +300,16 @@ class User
         $rows = $this->db->resultSet();
         $nbrRows = $this->db->rowCount();
 
+        $data = [];
+
         if ($nbrRows >= 0) {
 
             if ($nbrRows > 0) {
                 foreach ($rows as $row) {
                     $data[] = $row;
                 }
-                $_SESSION['notifications'] = $data;
             }
+            $_SESSION['notifications'] = $data;
             return $nbrRows;
         } else {
             return 0;

--- a/app/Router.php
+++ b/app/Router.php
@@ -97,6 +97,9 @@ class Router
                 case 'sendNotification':
                     $this->nutriController->sendNotification();
                     break;
+                case 'updateNotification':
+                    $this->userController->updateNotificationState();
+                    break;
                 default:
                     include __DIR__ . '/../Views/login.php';
                     exit;

--- a/app/Router.php
+++ b/app/Router.php
@@ -13,7 +13,6 @@ class Router
 {
     private $userController;
     private $adminController;
-
     private $resetPasswordController;
     private $recipesController;
     private $nutriController;
@@ -138,9 +137,13 @@ class Router
                         break;
                     case "countNotification":
                         $this->userController->countNotification();
+                        break;
                         // Add other GET actions here
                     case "getNutriClients":
                         $this->nutriController->getUsersForNutritionist();
+                        break;
+                    case "getUsersFromNotifications":
+                        $this->userController->getUsersFromNotifications();
                         break;
 
                     default:

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -1,16 +1,20 @@
 <?php foreach ($data as $row) :
     $statusText = '';
-    if ($row->notification_type == 0) {
+    $bgColor = '';
+    if ($row->notification_type == 3) {
         $statusText = 'Declined';
+        $bgColor = 'background-color:#F88F99'; // pourpre
     } elseif ($row->notification_type == 1) {
         $statusText = 'Waiting';
     } elseif ($row->notification_type == 2) {
         $statusText = 'Accepted';
+        $bgColor = 'background-color:#75d44c'; // verte
     } else {
         $statusText = 'Unknown'; // cas où la valeur de $row->notification_type n'est pas prévue
+        $bgColor = 'background-color:#4169E1'; // blue
     }
-
-?> <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer; <?= $style ?>" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
+?>
+    <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer;<?= $bgColor ?>" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
         <p style="width: 20%; margin: 10px 0">
             <?= htmlspecialchars($row->fullname) ?>
         </p>
@@ -27,15 +31,19 @@
             <?= $statusText ?>
         </p>
     </div>
-    <style>
-        .temp-bg-color {
-            background-color: #28E0B2;
-        }
-    </style>
 <?php endforeach; ?>
 
 <script>
     $(document).ready(function() {
+        function getUserFromNotif() {
+            performAjaxRequest(
+                "GET",
+                "getUsersFromNotifications",
+                "",
+                "",
+                ""
+            );
+        }
         $('[id^="accept-request-"]').on('click', function() {
             // Code à exécuter lorsque "Accept" est cliqué
 
@@ -48,6 +56,8 @@
                 "",
                 ""
             );
+            getUserFromNotif();
+
 
         });
 
@@ -63,6 +73,8 @@
                 "",
                 ""
             );
+            getUserFromNotif();
+
 
         });
     });

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -1,27 +1,47 @@
-<?php foreach ($data as $row) : ?>
-    <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-around; border-radius: 10px; cursor: pointer;" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
-        <p style="width: 30%; margin: 10px 0">
+<?php foreach ($data as $row) :
+    $statusText = '';
+    if ($row->notification_type == 0) {
+        $statusText = 'Declined';
+    } elseif ($row->notification_type == 1) {
+        $statusText = 'Waiting';
+    } elseif ($row->notification_type == 2) {
+        $statusText = 'Accepted';
+    } else {
+        $statusText = 'Unknown'; // cas où la valeur de $row->notification_type n'est pas prévue
+    }
+    $disableOptions = ''; // Par défaut, les options ne sont pas désactivées
+    if ($row->notification_type != 1) {
+        $disableOptions = 'disabled'; // Si le type n'est pas égal à 1 (Waiting), désactive les options
+    }
+?> <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer; <?= $style ?>" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
+        <p style="width: 20%; margin: 10px 0">
             <?= htmlspecialchars($row->fullname) ?>
         </p>
-        <p style="width: 26%; margin: 15px 0" id="accept-request-<?php echo $row->id ?>">
-            Accept
+        <?php if ($row->notification_type == 1) : // Si la notif est en attente on peut l'accepter ou décliner
+        ?>
+            <p style="width: 20%; margin: 15px 0" id="accept-request-<?php echo $row->id ?>">
+                Accept
+            </p>
+            <p style="width: 10%; margin: 15px 0" id="decline-request-<?php echo $row->id ?>">
+                Decline
+            </p>
+        <?php endif; ?>
+        <p style="width: 20%; margin: 15px 0" id="status-request-<?php echo $row->id ?>">
+            <?= $statusText ?>
         </p>
-        <p style="width: 10%; margin: 15px 0" id="decline-request-<?php echo $row->id ?>">
-            Decline
-        </p>
-
     </div>
     <style>
         .temp-bg-color {
             background-color: #28E0B2;
         }
     </style>
-
 <?php endforeach; ?>
+
 <script>
     $(document).ready(function() {
         $('[id^="accept-request-"]').on('click', function() {
             // Code à exécuter lorsque "Accept" est cliqué
+
             var userId = this.id.replace('accept-request-', '');
             console.log('Accept clicked for user ID:', userId);
             performAjaxRequest(
@@ -36,6 +56,7 @@
 
         $('[id^="decline-request-"]').on('click', function() {
             // Code à exécuter lorsque "Decline" est cliqué
+
             var userId = this.id.replace('decline-request-', '');
             console.log('Decline clicked for user ID:', userId);
             performAjaxRequest(

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -4,10 +4,10 @@
             <?= htmlspecialchars($row->fullname) ?>
         </p>
         <p style="width: 26%; margin: 15px 0">
-            <?= htmlspecialchars($row->email) ?>
+            Accept
         </p>
         <p style="width: 10%; margin: 15px 0">
-            <?= htmlspecialchars($row->age) ?> accepter
+            Decline
         </p>
 
     </div>

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -3,10 +3,10 @@
         <p style="width: 30%; margin: 10px 0">
             <?= htmlspecialchars($row->fullname) ?>
         </p>
-        <p style="width: 26%; margin: 15px 0">
+        <p style="width: 26%; margin: 15px 0" id="accept-request-<?php echo $row->id ?>">
             Accept
         </p>
-        <p style="width: 10%; margin: 15px 0">
+        <p style="width: 10%; margin: 15px 0" id="decline-request-<?php echo $row->id ?>">
             Decline
         </p>
 
@@ -18,3 +18,34 @@
     </style>
 
 <?php endforeach; ?>
+<script>
+    $(document).ready(function() {
+        $('[id^="accept-request-"]').on('click', function() {
+            // Code à exécuter lorsque "Accept" est cliqué
+            var userId = this.id.replace('accept-request-', '');
+            console.log('Accept clicked for user ID:', userId);
+            performAjaxRequest(
+                "POST",
+                "updateNotification",
+                "&notifState=Accept&senderId=" + userId,
+                "",
+                ""
+            );
+
+        });
+
+        $('[id^="decline-request-"]').on('click', function() {
+            // Code à exécuter lorsque "Decline" est cliqué
+            var userId = this.id.replace('decline-request-', '');
+            console.log('Decline clicked for user ID:', userId);
+            performAjaxRequest(
+                "POST",
+                "updateNotification",
+                "&notifState=Decline&senderId=" + userId,
+                "",
+                ""
+            );
+
+        });
+    });
+</script>

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -1,0 +1,20 @@
+<?php foreach ($data as $row) : ?>
+    <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-around; border-radius: 10px; cursor: pointer;" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
+        <p style="width: 30%; margin: 10px 0">
+            <?= htmlspecialchars($row->fullname) ?>
+        </p>
+        <p style="width: 26%; margin: 15px 0">
+            <?= htmlspecialchars($row->email) ?>
+        </p>
+        <p style="width: 10%; margin: 15px 0">
+            <?= htmlspecialchars($row->age) ?> accepter
+        </p>
+
+    </div>
+    <style>
+        .temp-bg-color {
+            background-color: #28E0B2;
+        }
+    </style>
+
+<?php endforeach; ?>

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -14,7 +14,7 @@
         $bgColor = 'background-color:#4169E1'; // blue
     }
 ?>
-    <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer;<?= $bgColor ?>" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
+    <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer;<?= $bgColor ?>" id="notif-user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
         <p style="width: 20%; margin: 10px 0">
             <?= htmlspecialchars($row->fullname) ?>
         </p>

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -9,10 +9,7 @@
     } else {
         $statusText = 'Unknown'; // cas où la valeur de $row->notification_type n'est pas prévue
     }
-    $disableOptions = ''; // Par défaut, les options ne sont pas désactivées
-    if ($row->notification_type != 1) {
-        $disableOptions = 'disabled'; // Si le type n'est pas égal à 1 (Waiting), désactive les options
-    }
+
 ?> <div class="d-flex container-fluid bg-dark-gray align-items-center text-white hoverscale client-user" style="width: 100%; justify-content: space-between; border-radius: 10px; cursor: pointer; <?= $style ?>" id="user-<?= $row->id ?>" data-user-id="<?= $row->id ?>" data-user-name="<?= $row->fullname ?>">
         <p style="width: 20%; margin: 10px 0">
             <?= htmlspecialchars($row->fullname) ?>

--- a/app/Views/components/user/dashboard/senderNotifList.php
+++ b/app/Views/components/user/dashboard/senderNotifList.php
@@ -56,7 +56,6 @@
                 "",
                 ""
             );
-            getUserFromNotif();
 
 
         });
@@ -73,9 +72,6 @@
                 "",
                 ""
             );
-            getUserFromNotif();
-
-
         });
     });
 </script>

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -150,7 +150,6 @@
     // pour effectuer une recherche
     function performSearch() {
       var inputValue = $('#client-list-search').val();
-      console.log(inputValue);
       performAjaxRequest(
         "GET",
         "clientSearch",

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -41,15 +41,17 @@
       <div>
         <a href="#" title="Close" class="modal-close">Close</a>
         <h1>Notifications</h1>
-        <div>gneur.</div>
+        <div>You can accept your requests here.</div>
         <br>
+        <div>Search for a specific notification using the search bar below.</div>
+
 
 
         <!-- Search bar -->
         <input type="text" class="form-control" name="client-list-search" id="client-list-search" placeholder="Search for client">
 
         <!-- Results -->
-        <div id="client-list-results" class="pt-4" style="max-height:350px; overflow:scroll;">
+        <div id="sender-notif-list" class="pt-4" style="max-height:350px; overflow:scroll;">
 
         </div>
       </div>
@@ -129,6 +131,19 @@
       );
     });
 
+    // pour récupérer les notifications 
+    $('#open-modal-notifs').on('click', function() {
+      performAjaxRequest(
+        "GET",
+        "getUsersFromNotifications",
+        "",
+        "",
+        ""
+      );
+      // Ajoutez la phrase au code HTML du modal
+      $('#open-modal-notifs').append('<p><?php echo "valeur test" ?></p>');
+    });
+
     function getNotif() {
       performAjaxRequest(
         "GET",
@@ -137,9 +152,7 @@
         "",
         ""
       );
-
     }
-
     getNotif();
 
     // pour effectuer une recherche

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -43,12 +43,6 @@
         <h1>Notifications</h1>
         <div>You can accept your requests here.</div>
         <br>
-        <div>Search for a specific notification using the search bar below.</div>
-
-
-
-        <!-- Search bar -->
-        <input type="text" class="form-control" name="client-list-search" id="client-list-search" placeholder="Search for client">
 
         <!-- Results -->
         <div id="sender-notif-list" class="pt-4" style="max-height:350px; overflow:scroll;">
@@ -62,7 +56,7 @@
       <a href="#open-modal">
         <div class="text-bg text-center d-flex align-items-center justify-content-center position-absolute" id="notif-displayer" style="font-size: 16px; height:30px; width:30px; border-radius: 100%; left: -40%; top:40%; z-index:0; background-color: #252624;"></div>
       </a>
-      <a href="#open-modal-notifs">
+      <a href="#open-modal-notifs" id="click-to-show-notif">
         <img src="<?= BASE_APP_DIR ?>/public/images/icons/bell.png" style="z-index:2;" alt="Image of a bell" />
       </a>
 
@@ -131,8 +125,8 @@
       );
     });
 
-    // pour récupérer les notifications 
-    $('#open-modal-notifs').on('click', function() {
+    // pour récupérer les users ayant envoyé des notifications 
+    $('#click-to-show-notif').on('click', function() {
       performAjaxRequest(
         "GET",
         "getUsersFromNotifications",
@@ -140,8 +134,6 @@
         "",
         ""
       );
-      // Ajoutez la phrase au code HTML du modal
-      $('#open-modal-notifs').append('<p><?php echo "valeur test" ?></p>');
     });
 
     function getNotif() {

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -125,15 +125,8 @@
       );
     });
 
-    // pour récupérer les users ayant envoyé des notifications 
-    performAjaxRequest(
-      "GET",
-      "getUsersFromNotifications",
-      "",
-      "",
-      ""
-    );
 
+    // pour récupérer le nombre de notif, et les mettre en session
     function getNotif() {
       performAjaxRequest(
         "GET",
@@ -143,7 +136,20 @@
         ""
       );
     }
+
+    // pour récupérer les users ayant envoyé des notifications 
+    function getUserFromNotif() {
+      performAjaxRequest(
+        "GET",
+        "getUsersFromNotifications",
+        "",
+        "",
+        ""
+      );
+    }
+
     getNotif();
+    getUserFromNotif();
 
     // pour effectuer une recherche
     function performSearch() {

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -126,15 +126,13 @@
     });
 
     // pour récupérer les users ayant envoyé des notifications 
-    $('#click-to-show-notif').on('click', function() {
-      performAjaxRequest(
-        "GET",
-        "getUsersFromNotifications",
-        "",
-        "",
-        ""
-      );
-    });
+    performAjaxRequest(
+      "GET",
+      "getUsersFromNotifications",
+      "",
+      "",
+      ""
+    );
 
     function getNotif() {
       performAjaxRequest(

--- a/app/Views/templates/user/dashboard.php
+++ b/app/Views/templates/user/dashboard.php
@@ -1,3 +1,22 @@
+<?php
+$messageDisplay = '';
+if ($_SESSION['role'] == "Regular") {
+  $messageDisplay = <<<HTML
+  <h1>Nutritionist list</h1>
+  <div>Search any nutritionist.</div>
+  HTML;
+} else if ($_SESSION['role'] == "Nutritionist") {
+  $messageDisplay = <<<HTML
+  <h1>Client list</h1>
+  <div>Search any client.</div>
+  HTML;
+} else {
+  $messageDisplay = <<<HTML
+  <h1>Not for admins</h1>
+  <div>Really no point.</div>
+  HTML;
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -23,8 +42,7 @@
     <div id="open-modal" class="modal-window">
       <div>
         <a href="#" title="Close" class="modal-close">Close</a>
-        <h1>Client list</h1>
-        <div>Search any client.</div>
+        <?php echo $messageDisplay ?>
         <br>
 
 

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -133,9 +133,23 @@ function performAjaxRequest(
           console.log("requestType log: " + response.requestType);
           var sender = response.data;
           console.log("data log: " + sender.fullname);
-
           console.log("succes log: " + response.success);
-          $("#notif-user-" + sender.id).html('<p>voici ' + sender.role + '.</p>');
+
+          if (response.requestType == "insert") {
+            var statusText = "Accepted";
+            var bgColor = "#75d44c";
+          }
+          else if (response.requestType == "delete") {
+            var statusText = "Declined";
+            var bgColor = "#F88F99";
+          }
+
+
+          $("#notif-user-" + sender.id).html(
+            '<p style="width: 20%; margin: 10px 0">' + sender.fullname + '</p>' +
+            '<p style="width: 20%; margin: 15px 0" id="status-request-<?php echo $row->id ?>">' + statusText + '</p>'
+          );
+          $("#notif-user-" + sender.id).css("background-color", bgColor);
           break;
 
         case "getUserDetails":

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -130,7 +130,12 @@ function performAjaxRequest(
           $("#sender-notif-list").html(response.data);
           break;
         case "updateNotification":
-          console.log("réponse de la requête: " + response.data);
+          console.log("requestType log: " + response.requestType);
+          var sender = response.data;
+          console.log("data log: " + sender.fullname);
+
+          console.log("succes log: " + response.success);
+          $("#notif-user-" + sender.id).html('<p>voici ' + sender.role + '.</p>');
           break;
 
         case "getUserDetails":

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -126,6 +126,10 @@ function performAjaxRequest(
           $("#notif-displayer").html(response.data);
           console.log("nombre de notifications: " + response.data);
           break;
+        case "getUsersFromNotifications":
+          $("#sender-notif-list").html(response.data);
+          console.log("les users: " + response.data);
+          break;
 
         case "getUserDetails":
           Swal.fire({

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -128,7 +128,6 @@ function performAjaxRequest(
           break;
         case "getUsersFromNotifications":
           $("#sender-notif-list").html(response.data);
-          console.log("les users: " + response.data);
           break;
 
         case "getUserDetails":

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -132,8 +132,8 @@ function performAjaxRequest(
         case "updateNotification":
           console.log("requestType log: " + response.requestType);
           var sender = response.data;
-          console.log("data log: " + sender.fullname);
-          console.log("succes log: " + response.success);
+          console.log("nom de l'user sender: " + sender.fullname);
+          console.log("success: " + response.success);
 
           if (response.requestType == "insert") {
             var statusText = "Accepted";

--- a/public/js/ajax.js
+++ b/public/js/ajax.js
@@ -129,6 +129,9 @@ function performAjaxRequest(
         case "getUsersFromNotifications":
           $("#sender-notif-list").html(response.data);
           break;
+        case "updateNotification":
+          console.log("réponse de la requête: " + response.data);
+          break;
 
         case "getUserDetails":
           Swal.fire({
@@ -151,6 +154,7 @@ function performAjaxRequest(
             showCancelButton: true,
           });
           break;
+
 
         default:
           console.log("Unhandled action: " + action);


### PR DESCRIPTION
Clicking on the bell icon displays notifications, sorting them to display pending notifications first. Accepting a notification will change its type and create a connection between the sender and the recipient of that notification. Declining a notification will change its type (to a different type than when accepted) and remove any existing connection between the two users involved. In both cases, AJAX will immediately update the display.

Clicking on the number indicating the notification count will bring up an interface allowing you to enter the name of a client (if you are a nutritionist) or a nutritionist (if you are a regular client). Typing part of a user's name in the search bar will suffice to display it.Clicking on a displayed name will send them a notification. Multiple clicks are allowed, but there cannot be more than 1 pending notification from one user to another, so it has no effect.

There is also now a function in User.php to retrieve a user's row based on their ID.


![image](https://github.com/uha-fr/archiweb_2024_projets_gr06/assets/103502603/7a982e78-6c59-41d1-a6b1-15afe5070969)


![image](https://github.com/uha-fr/archiweb_2024_projets_gr06/assets/103502603/c095ce91-584d-47cc-9dfc-1aaece5b19d5)
